### PR TITLE
Update bropper.py | Gave the user full control over the "waited" string

### DIFF
--- a/bropper.py
+++ b/bropper.py
@@ -98,7 +98,7 @@ class BROP:
         try:
             self.r = remote(self.host, self.port) if not reuse or not self.open else self.r
             self.open = True
-            self.r.recvuntil({f"{self.wait}\n"})
+            self.r.recvuntil({f"{self.wait}"})
             crash = False
             debug(f"# PAYLOAD : \np.send({payload})", append=True, display=False)
             self.r.send(payload)


### PR DESCRIPTION
Until now, the program waited for a string terminated with a line return (line 101) but it is not always the case so I just removed the \n to let the user fully control the awaited string 👍.